### PR TITLE
Add GraphAttentionTransformer layer

### DIFF
--- a/stellargraph/layer/__init__.py
+++ b/stellargraph/layer/__init__.py
@@ -41,3 +41,4 @@ from .graph_classification import *
 from .deep_graph_infomax import *
 from .sort_pooling import *
 from .gcn_lstm import *
+from .graph_attention_transformer import *

--- a/stellargraph/layer/graph_attention_transformer.py
+++ b/stellargraph/layer/graph_attention_transformer.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Graph Attention Transformer Layer."""
+
+import tensorflow as tf
+from tensorflow.keras import layers
+from tensorflow.keras import backend as K
+
+from .graph_attention import GraphAttention, GraphAttentionSparse
+from .misc import SqueezedSparseConversion
+
+__all__ = ["GraphAttentionTransformer"]
+
+
+class GraphAttentionTransformer(layers.Layer):
+    """Stack Graph Attention with a Transformer block.
+
+    This layer first applies a :class:`.GraphAttention` layer to the input
+    features and then processes the resulting representations using a
+    Transformer-style multi-head self-attention layer. The outputs of the GAT
+    and Transformer blocks are combined using an aggregation function.
+
+    The ``aggregator`` argument can be a string identifying one of the builtin
+    aggregation methods (``"add"``, ``"mean"`` or ``"concat"``) or a custom
+    callable that combines two tensors ``(gat_out, transformer_out)``.
+    """
+
+    def __init__(
+        self,
+        units,
+        attn_heads=1,
+        attn_heads_reduction="concat",
+        aggregator="add",
+        transformer_heads=1,
+        in_dropout_rate=0.0,
+        attn_dropout_rate=0.0,
+        activation="relu",
+        use_sparse=False,
+        **kwargs,
+    ):
+        self.units = units
+        self.attn_heads = attn_heads
+        self.attn_heads_reduction = attn_heads_reduction
+        self.aggregator = aggregator
+        self.transformer_heads = transformer_heads
+        self.in_dropout_rate = in_dropout_rate
+        self.attn_dropout_rate = attn_dropout_rate
+        self.activation = activation
+        self.use_sparse = use_sparse
+
+        gat_class = GraphAttentionSparse if use_sparse else GraphAttention
+        self.gat = gat_class(
+            units=units,
+            attn_heads=attn_heads,
+            attn_heads_reduction=attn_heads_reduction,
+            in_dropout_rate=in_dropout_rate,
+            attn_dropout_rate=attn_dropout_rate,
+            activation=activation,
+        )
+
+        self._set_agg_fn(aggregator)
+
+        self.transformer = layers.MultiHeadAttention(
+            num_heads=transformer_heads,
+            key_dim=self.gat.output_dim,
+            dropout=in_dropout_rate,
+        )
+        self.dropout = layers.Dropout(in_dropout_rate)
+        super().__init__(**kwargs)
+
+    def _set_agg_fn(self, agg):
+        if isinstance(agg, str):
+            if agg == "add":
+                self._agg_fn = lambda a, b: a + b
+            elif agg == "mean":
+                self._agg_fn = lambda a, b: (a + b) / 2.0
+            elif agg == "concat":
+                self._agg_fn = lambda a, b: K.concatenate([a, b], axis=-1)
+            else:
+                raise ValueError(f"Unknown aggregator '{agg}'")
+        elif callable(agg):
+            self._agg_fn = agg
+        else:
+            raise TypeError("aggregator must be a string or callable")
+
+    def get_config(self):
+        return {
+            "units": self.units,
+            "attn_heads": self.attn_heads,
+            "attn_heads_reduction": self.attn_heads_reduction,
+            "aggregator": self.aggregator,
+            "transformer_heads": self.transformer_heads,
+            "in_dropout_rate": self.in_dropout_rate,
+            "attn_dropout_rate": self.attn_dropout_rate,
+            "activation": self.activation,
+            "use_sparse": self.use_sparse,
+        }
+
+    def call(self, inputs, **kwargs):
+        if not isinstance(inputs, list):
+            raise TypeError(f"inputs: expected list, found {type(inputs).__name__}")
+
+        x_in, *A = inputs
+
+        if self.use_sparse:
+            if len(A) != 2:
+                raise ValueError("Sparse mode requires indices and values for adjacency")
+            A_indices, A_values = A
+            A_tensor = SqueezedSparseConversion(shape=(x_in.shape[1], x_in.shape[1]))(
+                [A_indices, A_values]
+            )
+            gat_out = self.gat([x_in, A_tensor])
+        else:
+            if len(A) != 1:
+                raise ValueError("Dense mode requires a single adjacency matrix")
+            gat_out = self.gat([x_in, A[0]])
+
+        trans_out = self.transformer(gat_out, gat_out)
+        trans_out = self.dropout(trans_out)
+
+        return self._agg_fn(gat_out, trans_out)

--- a/tests/layer/test_graph_attention_transformer.py
+++ b/tests/layer/test_graph_attention_transformer.py
@@ -1,0 +1,41 @@
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras.layers import Input
+
+from stellargraph.layer import GraphAttentionTransformer
+
+
+class TestGraphAttentionTransformer:
+    N = 4
+    F_in = 3
+
+    def get_inputs(self):
+        x = Input(batch_shape=(1, self.N, self.F_in))
+        A = Input(batch_shape=(1, self.N, self.N))
+        return [x, A]
+
+    def test_output_shapes_concat(self):
+        layer = GraphAttentionTransformer(
+            units=2,
+            attn_heads=1,
+            attn_heads_reduction="average",
+            aggregator="concat",
+            transformer_heads=1,
+        )
+        x_inp = self.get_inputs()
+        out = layer(x_inp)
+        assert out.shape.as_list() == [1, self.N, 4]
+
+    def test_custom_aggregator(self):
+        agg = lambda inputs0, inputs1: inputs0 - inputs1
+        layer = GraphAttentionTransformer(
+            units=2,
+            attn_heads=1,
+            attn_heads_reduction="average",
+            aggregator=agg,
+            transformer_heads=1,
+        )
+        x_inp = self.get_inputs()
+        out = layer(x_inp)
+        assert out.shape.as_list() == [1, self.N, 2]


### PR DESCRIPTION
## Summary
- add `GraphAttentionTransformer` for stacking a GraphAttention layer with a transformer block and a configurable aggregation
- export new layer
- test basic construction and aggregator behaviour

## Testing
- `pytest -k graph_attention_transformer -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_684cf603d0048320a5434c8575295d11