### PR TITLE
Fix custom aggregator output shape in GAT Transformer

### DIFF
--- a/stellargraph/layer/graph_attention_transformer.py
+++ b/stellargraph/layer/graph_attention_transformer.py
@@ -21,7 +21,10 @@ class GraphAttentionTransformer(layers.Layer):
 
     The ``aggregator`` argument can be a string identifying one of the builtin
     aggregation methods (``"add"``, ``"mean"`` or ``"concat"``) or a custom
-    callable that combines two tensors ``(gat_out, transformer_out)``.
+    callable that combines two tensors ``(gat_out, transformer_out)``. When a
+    callable is supplied, :meth:`compute_output_shape` infers the final feature
+    dimension by applying the aggregator to dummy tensors of the GAT output
+    shape.
     """
 
     def __init__(
@@ -67,7 +70,6 @@ class GraphAttentionTransformer(layers.Layer):
         self.dropout = layers.Dropout(in_dropout_rate)
         super().__init__(**kwargs)
 
-
     def build(self, input_shapes):
         # delegate building to the internal GAT layer
         self.gat.build(input_shapes)
@@ -76,10 +78,16 @@ class GraphAttentionTransformer(layers.Layer):
     def compute_output_shape(self, input_shapes):
         gat_shape = self.gat.compute_output_shape(input_shapes)
         out_dim = gat_shape[-1]
-        if isinstance(self.aggregator, str) and self.aggregator == "concat":
-            out_dim *= 2
-        return (gat_shape[0], gat_shape[1], out_dim)
 
+        if isinstance(self.aggregator, str):
+            if self.aggregator == "concat":
+                out_dim *= 2
+        else:
+            # determine the final dimension by applying the aggregator
+            dummy = tf.zeros((1, 1, out_dim))
+            out_dim = self._agg_fn(dummy, dummy).shape[-1]
+
+        return (gat_shape[0], gat_shape[1], out_dim)
 
     def _set_agg_fn(self, agg):
         if isinstance(agg, str):
@@ -117,7 +125,9 @@ class GraphAttentionTransformer(layers.Layer):
 
         if self.use_sparse:
             if len(A) != 2:
-                raise ValueError("Sparse mode requires indices and values for adjacency")
+                raise ValueError(
+                    "Sparse mode requires indices and values for adjacency"
+                )
             A_indices, A_values = A
             A_tensor = SqueezedSparseConversion(shape=(x_in.shape[1], x_in.shape[1]))(
                 [A_indices, A_values]

--- a/tests/layer/test_graph_attention_transformer.py
+++ b/tests/layer/test_graph_attention_transformer.py
@@ -39,3 +39,21 @@ class TestGraphAttentionTransformer:
         x_inp = self.get_inputs()
         out = layer(x_inp)
         assert out.shape.as_list() == [1, self.N, 2]
+
+    def test_custom_aggregator_dimension_change(self):
+        def agg(a, b):
+            c = tf.concat([a, b], axis=-1)
+            return c[:, :, :-1]
+
+        layer = GraphAttentionTransformer(
+            units=2,
+            attn_heads=1,
+            attn_heads_reduction="average",
+            aggregator=agg,
+            transformer_heads=1,
+        )
+
+        x_inp = self.get_inputs()
+        out = layer(x_inp)
+        assert out.shape.as_list() == [1, self.N, 3]
+        assert layer.compute_output_shape([t.shape for t in x_inp]) == (1, self.N, 3)


### PR DESCRIPTION
## Summary
- support custom callables for output shape calculation in `GraphAttentionTransformer`
- document shape inference for callables
- test aggregator that changes feature dimensions
- format code with `black`

## Testing
- `black --check stellargraph/layer/graph_attention_transformer.py tests/layer/test_graph_attention_transformer.py`
- `pytest -q tests/layer/test_graph_attention_transformer.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684d0f16a98483209098247d20b9e3cc