### PR TITLE
Fix GAT time-series demo

### DIFF
--- a/demos/time-series/README.md
+++ b/demos/time-series/README.md
@@ -11,4 +11,8 @@ These demos are displayed with detailed descriptions in the documentation: https
 | [Forecasting with GAT + Transformer](https://stellargraph.readthedocs.io/en/stable/demos/time-series/gat-transformer-time-series.html) | [source](gat-transformer-time-series.ipynb) |
 
 The demo titles link to the latest, nicely rendered version. The 'source' links will open the demo in the application in which this README is being viewed, such as Jupyter Lab (ready for execution).
+
+When using the `METR_LA` dataset, transpose the `trainX` and `testX` arrays returned by
+`sequence_data_preparation` so that they have shape `(samples, nodes, seq_len)` before
+training the `GATTransformer` model.
 <!-- DOCS LINKS -->

--- a/demos/time-series/gat-transformer-time-series.ipynb
+++ b/demos/time-series/gat-transformer-time-series.ipynb
@@ -1,1 +1,46 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Forecasting using GAT + Transformer\n"]}, {"cell_type": "code", "metadata": {}, "source": "from stellargraph.datasets import METR_LA\nfrom stellargraph.layer.gat_transformer import GATTransformer\nfrom tensorflow.keras import Model\n"}, {"cell_type": "code", "metadata": {}, "source": "dataset = METR_LA()\ndata, adj = dataset.load()\ntrain, test = dataset.train_test_split(data, 0.8)\ntrain, test = dataset.scale_data(train, test)\ntrainX, trainY, testX, testY = dataset.sequence_data_preparation(12, 1, train, test)\n"}, {"cell_type": "code", "metadata": {}, "source": "layer = GATTransformer(seq_len=12, adj=adj, gat_layer_sizes=[4], transformer_layers=1)\nx_inp, x_out = layer.in_out_tensors()\nmodel = Model(inputs=x_inp, outputs=x_out)\nmodel.compile(optimizer=\"adam\", loss=\"mae\")\nmodel.fit(trainX, trainY, epochs=1, batch_size=8)\n"}, {"cell_type": "code", "metadata": {}, "source": "pred = model.predict(testX[:1])\nprint(pred.shape)\n"}], "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"}, "language_info": {"name": "python", "codemirror_mode": {"name": "ipython", "version": 3}}}, "nbformat": 4, "nbformat_minor": 4}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Forecasting using GAT + Transformer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "from stellargraph.datasets import METR_LA\nfrom stellargraph.layer.gat_transformer import GATTransformer\nfrom tensorflow.keras import Model\n"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "dataset = METR_LA()\ndata, adj = dataset.load()\ntrain, test = dataset.train_test_split(data, 0.8)\ntrain, test = dataset.scale_data(train, test)\ntrainX, trainY, testX, testY = dataset.sequence_data_preparation(12, 1, train, test)\n\ntrainX = trainX.transpose((0, 2, 1))  # GAT expects (samples, nodes, seq_len)\ntestX = testX.transpose((0, 2, 1))"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "layer = GATTransformer(seq_len=12, adj=adj, gat_layer_sizes=[4], transformer_layers=1)\nx_inp, x_out = layer.in_out_tensors()\nmodel = Model(inputs=x_inp, outputs=x_out)\nmodel.compile(optimizer=\"adam\", loss=\"mae\")\nmodel.fit(trainX, trainY, epochs=1, batch_size=8)\n"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "pred = model.predict(testX[:1])\nprint(pred.shape)\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- transpose the METR_LA sequences for GAT demo
- note this requirement in the time-series README

## Testing
- `pytest -q` *(fails: FileNotFoundError due to blocked dataset downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d3afbf08320969167616ae932cc