### PR TITLE
Add Kalman GAT Transformer demo

### DIFF
--- a/demos/time-series/README.md
+++ b/demos/time-series/README.md
@@ -9,6 +9,7 @@ These demos are displayed with detailed descriptions in the documentation: https
 |---|---|
 | [Forecasting using spatio-temporal data with combined Graph Convolution + LSTM model](https://stellargraph.readthedocs.io/en/stable/demos/time-series/gcn-lstm-time-series.html) | [source](gcn-lstm-time-series.ipynb) |
 | [Forecasting with GAT + Transformer](https://stellargraph.readthedocs.io/en/stable/demos/time-series/gat-transformer-time-series.html) | [source](gat-transformer-time-series.ipynb) |
+| [Forecasting with Kalman GAT + Transformer](https://stellargraph.readthedocs.io/en/stable/demos/time-series/kalman-gat-transformer-time-series.html) | [source](kalman-gat-transformer-time-series.ipynb) |
 
 The demo titles link to the latest, nicely rendered version. The 'source' links will open the demo in the application in which this README is being viewed, such as Jupyter Lab (ready for execution).
 

--- a/demos/time-series/kalman-gat-transformer-time-series.ipynb
+++ b/demos/time-series/kalman-gat-transformer-time-series.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Forecasting using Kalman GAT + Transformer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from stellargraph.datasets import METR_LA\n",
+    "from stellargraph.layer.kalman_gat_transformer import KalmanGATTransformer\n",
+    "from tensorflow.keras import Model\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "dataset = METR_LA()\n",
+    "data, adj = dataset.load()\n",
+    "train, test = dataset.train_test_split(data, 0.8)\n",
+    "train, test = dataset.scale_data(train, test)\n",
+    "trainX, trainY, testX, testY = dataset.sequence_data_preparation(12, 1, train, test)\n",
+    "\n",
+    "trainX = trainX.transpose((0, 2, 1))  # GAT expects (samples, nodes, seq_len)\n",
+    "testX = testX.transpose((0, 2, 1))\n",
+    "print(trainX.shape)\n",
+    "print(testX.shape)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "layer = KalmanGATTransformer(seq_len=12, adj=adj, gat_layer_sizes=[4], transformer_layers=1)\n",
+    "x_inp, x_out = layer.in_out_tensors()\n",
+    "model = Model(inputs=x_inp, outputs=x_out)\n",
+    "model.compile(optimizer=\"adam\", loss=\"mae\")\n",
+    "model.fit(trainX, trainY, epochs=1, batch_size=8)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "pred = model.predict(testX[:1])\n",
+    "print(pred.shape)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/stellargraph/layer/__init__.py
+++ b/stellargraph/layer/__init__.py
@@ -43,3 +43,4 @@ from .sort_pooling import *
 from .gcn_lstm import *
 from .graph_attention_transformer import *
 from .gat_transformer import *
+from .kalman_gat_transformer import *

--- a/stellargraph/layer/kalman_gat_transformer.py
+++ b/stellargraph/layer/kalman_gat_transformer.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Kalman GAT Transformer layer."""
+
+import tensorflow as tf
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import Layer, Dropout, Dense, MultiHeadAttention
+
+from .gat_transformer import GATTransformer
+
+
+class KalmanFilterAttention(Layer):
+    """A simple learnable Kalman filter with attention."""
+
+    def __init__(self, units, num_heads=1, dropout=0.0, **kwargs):
+        super().__init__(**kwargs)
+        self.units = units
+        self.num_heads = num_heads
+        self.dropout = Dropout(dropout)
+        self.state_dense = Dense(units)
+        self.obs_dense = Dense(units)
+        self.attn = MultiHeadAttention(
+            num_heads=num_heads, key_dim=units, dropout=dropout
+        )
+        self.out_dense = Dense(units)
+
+    def call(self, inputs):
+        # inputs: B x T x F
+        inputs_T = tf.transpose(inputs, [1, 0, 2])  # T x B x F
+        batch_size = tf.shape(inputs)[0]
+        init_state = tf.zeros((batch_size, self.units))
+
+        def step(prev, obs):
+            pred = self.state_dense(prev)
+            obs_p = self.obs_dense(obs)
+            attn = self.attn(
+                tf.expand_dims(pred, 1),
+                tf.expand_dims(obs_p, 1),
+                tf.expand_dims(obs_p, 1),
+            )
+            attn = tf.squeeze(attn, 1)
+            new_state = pred + attn
+            return new_state
+
+        states = tf.scan(step, inputs_T, initializer=init_state)
+        states = tf.transpose(states, [1, 0, 2])  # B x T x units
+        states = self.dropout(states)
+        return self.out_dense(states)
+
+
+class KalmanGATTransformer(GATTransformer):
+    """GAT Transformer preceded by a learnable Kalman filter."""
+
+    def __init__(
+        self, *args, kalman_units=None, kalman_heads=1, kalman_dropout=0.0, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        if kalman_units is None:
+            kalman_units = self.variates
+        self.kalman_filter = KalmanFilterAttention(
+            kalman_units, num_heads=kalman_heads, dropout=kalman_dropout
+        )
+
+    def _apply_kalman(self, x):
+        # x: B x N x T x V
+        def fn(t):
+            t = tf.reshape(t, (-1, self.seq_len, self.variates))
+            t = self.kalman_filter(t)
+            return tf.reshape(t, (-1, self.n_nodes, self.seq_len, self.variates))
+
+        return tf.keras.layers.Lambda(fn)(x)
+
+    def __call__(self, x):
+        x_in, out_idx = x
+        h = x_in
+        if not self.multivariate_input:
+            h = tf.keras.layers.Lambda(lambda x: tf.expand_dims(x, axis=-1))(h)
+        h = self._apply_kalman(h)
+        if not self.multivariate_input:
+            h = tf.keras.layers.Lambda(lambda x: tf.squeeze(x, axis=-1))(h)
+        return super().__call__((h, out_idx))

--- a/tests/layer/test_kalman_gat_transformer.py
+++ b/tests/layer/test_kalman_gat_transformer.py
@@ -1,0 +1,23 @@
+import numpy as np
+from tensorflow.keras import Model
+
+from stellargraph.layer.kalman_gat_transformer import KalmanGATTransformer
+
+
+def get_timeseries_graph_data():
+    featuresX = np.random.rand(4, 5, 3)
+    featuresY = np.random.rand(4, 5)
+    adj = np.random.randint(0, 2, size=(5, 5))
+    return featuresX, featuresY, adj
+
+
+def test_kalman_gat_transformer_model():
+    fx, fy, a = get_timeseries_graph_data()
+    model_layer = KalmanGATTransformer(
+        seq_len=fx.shape[-1], adj=a, gat_layer_sizes=[2], transformer_layers=1
+    )
+    x_input, x_output = model_layer.in_out_tensors()
+    model = Model(inputs=x_input, outputs=x_output)
+    model.compile(optimizer="adam", loss="mae")
+    history = model.fit(fx, fy, epochs=2, batch_size=1, verbose=0)
+    assert len(history.history["loss"]) == 2


### PR DESCRIPTION
## Summary
- add `kalman-gat-transformer-time-series.ipynb` demo notebook using METR-LA
- list the demo in the time-series README
- format Kalman layer and its tests with Black

## Testing
- `black stellargraph/layer/kalman_gat_transformer.py tests/layer/test_kalman_gat_transformer.py`
- `pytest tests/layer/test_kalman_gat_transformer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684dab054e748320845f1df0ddd9952b